### PR TITLE
Use BTreeMap instead of hashmap so that keys are always sorted in the…

### DIFF
--- a/gen-key-file/src/main.rs
+++ b/gen-key-file/src/main.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::Path;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 extern crate clap;
 extern crate serde_json;
@@ -34,7 +34,7 @@ fn main() {
     let key_file = m.value_of("key_file").unwrap();
 
 
-    let mut keys = HashMap::new();
+    let mut keys = BTreeMap::new();
 
     for path in fs::read_dir(&key_dir).unwrap() {
         let key = String::from(path.unwrap().file_name().to_string_lossy());


### PR DESCRIPTION
By design, rust HashMap implementation seeds the hashing function with a random value - see https://doc.rust-lang.org/std/collections/struct.HashMap.html. As a result, iteration order is different on every run of the utility. While this is not affecting functionality, having a consistent order helps with reviewing differences in the output. A BTreeMap is always sorted, so iterating it produces consistent results.